### PR TITLE
chore: update vscode-icons submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
+## 1.1.1 - 2024-01-11
 
 ### Fixed
 
-### Security
+- `flake.lock` icon.
+- `yarn` icon.
+- `yarn.lock` icon.
 
 ## 1.1.0 - 2024-01-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,22 @@
 # Changelog
 
-## 1.1.1 - 2024-01-11
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
 
 ### Fixed
 
 - `flake.lock` icon.
 - `yarn` icon.
 - `yarn.lock` icon.
+
+### Security
 
 ## 1.1.0 - 2024-01-01
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup = com.github.catppuccin.jetbrains_icons
 pluginName = Catppuccin Icons
-pluginVersion = 1.1.0
+pluginVersion = 1.1.1
 pluginSinceBuild = 231
 pluginUntilBuild = 233.*
 platformType = IC


### PR DESCRIPTION
This PR fixes #17 with by using the new version from `vscode-icons` https://github.com/catppuccin/vscode-icons/pull/68

Feel free to drop #69db17f091b5a7bc2dae9970737d85119c35dad5 or #431b9ec49db7eb0fcd0d77cd3b7d36191727d75a if it does not match how you release.