### PR TITLE
Fix python icon in files tree

### DIFF
--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/ProjectViewNodeDecorator.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/ProjectViewNodeDecorator.kt
@@ -1,0 +1,26 @@
+package com.github.catppuccin.jetbrains_icons
+
+import com.github.catppuccin.jetbrains_icons.settings.PluginSettingsState
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNodeDecorator
+import com.intellij.packageDependencies.ui.PackageDependenciesNode
+import com.intellij.ui.ColoredTreeCellRenderer
+
+// hack: pycharm python plugin overrides .py icons in files tree
+// by using ProjectViewNodeDecorator we can override it with our icon
+class ProjectViewNodeDecorator: ProjectViewNodeDecorator {
+    private var icons = Icons(PluginSettingsState.instance.variant)
+
+    override fun decorate(node: ProjectViewNode<*>, data: PresentationData) {
+        val file_type = node.getVirtualFile()?.name?.split(".")?.last()
+
+        if (file_type.equals("py")) {
+            data.setIcon(icons.EXT_TO_ICONS["py"])
+        }
+    }
+
+    // deprecated
+    override fun decorate(node: PackageDependenciesNode, cellRender: ColoredTreeCellRenderer) {
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,10 @@ For further help, see also:
       order="first"
       id="IconProvider"
     />
+    <projectViewNodeDecorator
+      implementation="com.github.catppuccin.jetbrains_icons.ProjectViewNodeDecorator"
+      id="ProjectViewNodeDecorator"
+    />
     <applicationConfigurable
       parentId="appearance"
       groupId="com.github.catppuccin.jetbrains_icons"


### PR DESCRIPTION
Fixes #19 
It looks like that it is the only way to override python icon in files tree: https://youtrack.jetbrains.com/issue/PY-44417/IconProvider-doesnt-replace-Python-Icons