### PR TITLE
ci: add workflow to update the vscode-icons submodule

### DIFF
--- a/.github/workflows/vscode-icons.yml
+++ b/.github/workflows/vscode-icons.yml
@@ -1,0 +1,37 @@
+name: Update vscode-icons
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Update submodule
+        id: update_submodule
+        run: |
+          git submodule update --remote
+          cd generate/vscode-icons/
+          tag=$(git describe --abbrev=0 --tags)
+          git reset --hard "$tag"
+          echo "latest_tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'feat: update vscode-icons submodule to ${{ steps.update_submodule.outputs.latest_tag }}'
+          branch: 'feat/update-vscode-icons-${{ steps.update_submodule.outputs.latest_tag }}'
+          title: 'feat: update vscode-icons submodule to ${{ steps.update_submodule.outputs.latest_tag }}'
+          body: |
+            This automated PR updates the [catppuccin/vscode-icons](https://github.com/catppuccin/vscode-icons) submodule to  ${{ steps.update_submodule.outputs.latest_tag }}.


### PR DESCRIPTION
Adds a workflow I've been using over at https://github.com/catppuccin/github-file-explorer-icons to automatically raise a pull request when a new release is made at https://github.com/catppuccin/vscode-icons.