### PR TITLE
ci/update pnpm action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         run: corepack enable
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9.1.2
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
- **ci: remove `version` from pnpm setup action**
  This field is optional if we have specified
  the `packageManager` field in our `package.json`
  

- **chore(deps): update pnpm/action-setup to v4**
  