### PR TITLE
fix: lazily initialize PluginSettingsState in IconPack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Lazily initialize PluginSettingsState in IconPack ([#81](https://github.com/catppuccin/jetbrains-icons/pull/81))
 - Display correct coloured Java icons in editor tabs ([#68](https://github.com/catppuccin/jetbrains-icons/pull/68))
 
 ### Security

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/IconPack.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/IconPack.kt
@@ -3,7 +3,9 @@ package com.github.catppuccin.jetbrains_icons
 import com.github.catppuccin.jetbrains_icons.settings.PluginSettingsState
 
 class IconPack {
-    val icons = Icons(PluginSettingsState.instance.variant)
+    val icons: Icons by lazy {
+        Icons(PluginSettingsState.instance.variant)
+    }
 
     companion object {
         val instance = IconPack()


### PR DESCRIPTION
Addresses [Exception: Class initialization must not depend on services. Consider using instance of the service on-demand instead.](https://github.com/catppuccin/jetbrains-icons/issues/75)