### PR TITLE
fix: make kotlin & java modules optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Make `org.jetbrains.kotlin` and `com.intellij.java` modules optional. This reintroduces support for IDEs outside IntelliJ, Android Studio & Aqua. ([#86](https://github.com/catppuccin/jetbrains-icons/pull/86)) 
+
 ### Security
 
 ## 1.6.1 - 2024-08-09

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
-pluginVersion=1.6.2
+pluginVersion=1.6.1
 pluginSinceBuild=231
 pluginUntilBuild=242.*
 platformType=IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
-pluginVersion=1.6.1
+pluginVersion=1.6.2
 pluginSinceBuild=231
 pluginUntilBuild=242.*
 platformType=IC

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,8 +31,8 @@ For further help, see also:
 <p>LICENSE: <a href="https://github.com/catppuccin/jetbrains-icons/blob/main/LICENSE">MIT</a></p>
 ]]></description>
   <depends>com.intellij.modules.platform</depends>
-  <depends>org.jetbrains.kotlin</depends>
-  <depends>com.intellij.java</depends>
+  <depends optional="true">org.jetbrains.kotlin</depends>
+  <depends optional="true">com.intellij.java</depends>
   <extensions defaultExtensionNs="com.intellij">
     <iconProvider
       implementation="com.github.catppuccin.jetbrains_icons.IconProvider"


### PR DESCRIPTION
Fix https://github.com/catppuccin/jetbrains-icons/issues/85, tested on PHPStorm 2024.2 & Intellij IDEA 2024.2 and working well.