### PR TITLE
build: fix plugin defects

### DIFF
--- a/src/main/resources/META-INF/com.github.catppuccin.jetbrains_icons-withJava.xml
+++ b/src/main/resources/META-INF/com.github.catppuccin.jetbrains_icons-withJava.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/com.github.catppuccin.jetbrains_icons-withKotlin.xml
+++ b/src/main/resources/META-INF/com.github.catppuccin.jetbrains_icons-withKotlin.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,8 +31,8 @@ For further help, see also:
 <p>LICENSE: <a href="https://github.com/catppuccin/jetbrains-icons/blob/main/LICENSE">MIT</a></p>
 ]]></description>
   <depends>com.intellij.modules.platform</depends>
-  <depends optional="true">org.jetbrains.kotlin</depends>
-  <depends optional="true">com.intellij.java</depends>
+  <depends optional="true" config-file="com.github.catppuccin.jetbrains_icons-withKotlin.xml">org.jetbrains.kotlin</depends>
+  <depends optional="true" config-file="com.github.catppuccin.jetbrains_icons-withJava.xml">com.intellij.java</depends>
   <extensions defaultExtensionNs="com.intellij">
     <iconProvider
       implementation="com.github.catppuccin.jetbrains_icons.IconProvider"


### PR DESCRIPTION
Currently unsure about what to include in the optional file that the [JetBrains Docs](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#optional-plugin-dependencies) specify.

Looks like we'll most likely want a refactor so that different IconProviders are registered on Java and Kotlin IDEs.