### PR TITLE
feat: differentiate Java files by colour & shape in the file tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Differentiate Java files (Annotation, Class, Enum, etc.) by colour and shape in the file tree. If you know how to
+  implement these icons in the rest of the user interface, please reach out to us via the issue tracker or the
+  Catppuccin discord!
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Differentiate Java files (Annotation, Class, Enum, etc.) by colour and shape in the file tree. If you know how to
   implement these icons in the rest of the user interface, please reach out to us via the issue tracker or the
   Catppuccin discord!
+- Upgrade submodule `vscode-icons` from v1.15.0 to v1.16.0 (See [vscode-icons CHANGELOG.md](https://github.com/catppuccin/vscode-icons/blob/main/CHANGELOG.md#v1160) for added icons and associations)
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
-pluginVersion=1.7.0
+pluginVersion=1.8.0
 pluginSinceBuild=231
 pluginUntilBuild=242.*
 platformType=IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
-pluginVersion=1.8.0
+pluginVersion=1.9.0
 pluginSinceBuild=231
 pluginUntilBuild=242.*
 platformType=IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
-pluginVersion=1.9.0
+pluginVersion=1.8.0
 pluginSinceBuild=231
 pluginUntilBuild=242.*
 platformType=IC

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/IconProvider.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/IconProvider.kt
@@ -74,10 +74,13 @@ class IconProvider : IconProvider() {
         file.accept(object : JavaRecursiveElementVisitor() {
             override fun visitClass(aClass: PsiClass) {
                 when {
+                    aClass.isAnnotationType -> fileType = "JAVA_ANNOTATION"
                     aClass.isInterface -> fileType = "JAVA_INTERFACE"
                     aClass.isEnum -> fileType = "JAVA_ENUM"
-                    aClass.isAnnotationType -> fileType = "JAVA_ANNOTATION"
                     aClass.isRecord -> fileType = "JAVA_RECORD"
+                    PsiClassUtils.isException(aClass) -> fileType = "JAVA_EXCEPTION"
+                    PsiClassUtils.isSealed(aClass) -> fileType = "JAVA_SEALED"
+                    PsiClassUtils.isFinal(aClass) -> fileType = "JAVA_FINAL"
                     PsiClassUtils.isAbstract(aClass) -> fileType = "JAVA_ABSTRACT"
                 }
             }
@@ -87,12 +90,15 @@ class IconProvider : IconProvider() {
 
     private fun provideJavaIcons(): Map<String, Icon> {
         return mapOf(
-            "JAVA_INTERFACE" to icons.java_alt_1,
-            "JAVA_ENUM" to icons.java_alt_3,
-            "JAVA_ANNOTATION" to icons.java_alt_1,
-            "JAVA_RECORD" to icons.java_alt_2,
-            "JAVA_ABSTRACT" to icons.java_alt_1,
-            "JAVA_CLASS" to icons.java,
+            "JAVA_ANNOTATION" to icons.java_annotation,
+            "JAVA_INTERFACE" to icons.java_interface,
+            "JAVA_ENUM" to icons.java_enum,
+            "JAVA_RECORD" to icons.java_record,
+            "JAVA_EXCEPTION" to icons.java_exception,
+            "JAVA_ABSTRACT" to icons.java_class_abstract,
+            "JAVA_SEALED" to icons.java_class_sealed,
+            "JAVA_FINAL" to icons.java_class_final,
+            "JAVA_CLASS" to icons.java_class,
         )
     }
 }

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/util/PsiClassUtils.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/util/PsiClassUtils.kt
@@ -7,4 +7,16 @@ object PsiClassUtils {
     fun isAbstract(psiClass: PsiClass): Boolean {
         return psiClass.hasModifierProperty(PsiModifier.ABSTRACT)
     }
+
+    fun isSealed(psiClass: PsiClass): Boolean {
+        return psiClass.hasModifierProperty(PsiModifier.SEALED)
+    }
+
+    fun isFinal(psiClass: PsiClass): Boolean {
+        return psiClass.hasModifierProperty(PsiModifier.FINAL)
+    }
+
+    fun isException(psiClass: PsiClass): Boolean {
+        return psiClass.name!!.endsWith("com.github.catppuccin.jetbrains_icons.test.Exception")
+    }
 }

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/util/PsiClassUtils.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/util/PsiClassUtils.kt
@@ -17,6 +17,6 @@ object PsiClassUtils {
     }
 
     fun isException(psiClass: PsiClass): Boolean {
-        return psiClass.name!!.endsWith("com.github.catppuccin.jetbrains_icons.test.Exception")
+        return psiClass.name!!.endsWith("Exception")
     }
 }


### PR DESCRIPTION
This PR (finally!) updates the icons to allow Java files to be differentiated by colour and shape, as shown in the screenshot below:

![image](https://github.com/user-attachments/assets/02047908-590c-4fd6-9674-0dcf1f543bc1)

I think they look _awesome_. Currently waiting on https://github.com/catppuccin/vscode-icons/issues/161 to be resolved and a new release to be created before merging this one.

Closes #42 