### PR TITLE
revert: "chore(deps): update dependency gradle to v8.10.1"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ tasks {
     }
 
     wrapper {
-        gradleVersion = "8.10.1"
+        gradleVersion = "8.10"
     }
 
     patchPluginXml {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Reverts catppuccin/jetbrains-icons#107

Gradle version `8.10.1` includes a [regression](https://github.com/gradle/gradle/issues/30472) which has caused our CI pipeline to [fail](https://github.com/catppuccin/jetbrains-icons/actions/runs/10842263501/job/30087602874).