### PR TITLE
feat: support `.razor` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add icon for `.razor` files.
+
 ### Changed
 
 - Update IntelliJ Platform plugin to 2.1.0 ([#125](https://github.com/catppuccin/jetbrains-icons/pull/125))

--- a/generate/scripts/generate.ts
+++ b/generate/scripts/generate.ts
@@ -13,6 +13,11 @@ function generateIcons(variant: string) {
   });
 }
 
+// VSCode sometimes doesn't need the `fileExtension` block to be populated but that affects JetBrains so we can add our
+// own extensions/overrides here if need be.
+const customFileExtensions = {razor: "razor"}
+const extendedFileExtensions = {...fileExtensions, ...customFileExtensions}
+
 function generateIconsKt() {
   let data = `package com.github.catppuccin.jetbrains_icons
 
@@ -46,7 +51,7 @@ class Icons(private val variant: String) {`
 
   // Extensions to Icons
   data += `\n    val EXT_TO_ICONS = mapOf(\n`
-  Object.entries(fileExtensions).forEach(([key, value]: [string, string]) => {
+  Object.entries(extendedFileExtensions).forEach(([key, value]: [string, string]) => {
     data += `        "${key}" to ${value.replaceAll('-', '_')},\n`
   })
   data += `    )\n`


### PR DESCRIPTION
This PR adds support for the `.razor` extension and also support for extending the list of filename extensions returned by catppuccin/vscode-icons.

This will hopefully avoid the need for PRs such as https://github.com/catppuccin/vscode-icons/pull/317 where the configuration is unnecessary on VSCode's end.

It's worth noting that in the future, we plan to decouple the vscode icons extension and the code icons themselves which should eliminate the need for this type of discrepancy.