### PR TITLE
ci(gradle): migrate to supported gradle action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 
+permissions: read-all
+
 on:
   workflow_dispatch:
   push:
@@ -29,15 +31,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 17
           cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@
 
 name: Publish
 
+permissions: read-all
+
 on:
   push:
     tags:
@@ -16,14 +18,13 @@ jobs:
   build:
     name: Publish Plugin
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -31,6 +32,9 @@ jobs:
           distribution: zulu
           java-version: 17
           cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3

--- a/.github/workflows/vscode-icons.yml
+++ b/.github/workflows/vscode-icons.yml
@@ -1,5 +1,7 @@
 name: Update vscode-icons
 
+permissions: read-all
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve permissions and setup steps. The key changes involve adding read permissions, updating Java and Gradle setup steps, and removing the Gradle Wrapper validation step.

Gradle unified all it's actions into one larger action package. Before, we used the standalone gradle wrapper validation action, which has been replaced by the wrapper-validation action as part of the gradle/actions repository.
Since we're using a version newer or equal to 4.0 for the new Gradle actions, the setup-gradle action automatically performs this validation itself, therefore negating the need for a separate step.

Permissions updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R3-R4): Added `read-all` permissions to the build workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R10-R11): Added `read-all` permissions to the publish workflow and `contents: write` permissions to the build job. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R10-R11) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R21-R38)
* [`.github/workflows/vscode-icons.yml`](diffhunk://#diff-bfd85d9d3affc48ef56e85698a49d6fae6d8db2ce0194bece868e2311d5dfddeR3-R4): Added `read-all` permissions to the vscode-icons update workflow.

Setup steps updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L32-R43): Removed the Gradle Wrapper validation step and added a step to set up Gradle.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R21-R38): Removed the Gradle Wrapper validation step and added a step to set up Gradle.