### PR TITLE
build: remove until-build restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Removed the `until-build` restriction, the plugin now stays compatible with all future IDE versions without needing a release per IDE version
+
 ### Deprecated
 
 ### Removed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,9 @@ tasks {
   patchPluginXml {
     pluginVersion.set(properties("pluginVersion"))
     sinceBuild.set(properties("pluginSinceBuild"))
-    untilBuild.set(properties("pluginUntilBuild"))
+    // Unset so the plugin declares compatibility with all IDE versions from since-build onwards.
+    // An empty gradle.properties value would produce until-build="" instead of removing the attribute.
+    untilBuild.set(provider { null })
 
     // Get the latest available change notes from the changelog file
     changeNotes.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
 pluginVersion=1.13.1
 pluginSinceBuild=231
-pluginUntilBuild=261.*
 platformType=IC
 platformVersion=2023.1
 platformPlugins=org.jetbrains.kotlin,com.intellij.java


### PR DESCRIPTION
## What

Removes the `until-build` attribute from the plugin manifest by unsetting `untilBuild` in `patchPluginXml` (`provider { null }`) and dropping the `pluginUntilBuild` property. The patched `plugin.xml` now contains:

```xml
<idea-version since-build="231" />
```

which declares compatibility with all IDE versions from 231 onwards.

## Why

Every new IDE version (including EAPs) currently requires a one-line `pluginUntilBuild` bump and a release (see #262 and the previous per-version bumps). The plugin only uses stable platform APIs (`IconProvider`, `applicationConfigurable`/`applicationService`, `ProjectActivity`, `IconPathPatcher`), and its failure modes on a hypothetical breaking IDE version are graceful (icons fall back to platform defaults). [JetBrains' docs](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html) support omitting `until-build` for plugins in this situation.

Safety valves that remain in place:
- CI runs the Plugin Verifier against `recommended()` IDEs, so verifier breakage on new releases still surfaces in PRs.
- Marketplace allows editing the compatibility range of already-published versions retroactively if a future IDE ever does break the plugin.

## Notes

- Simply emptying the property (`pluginUntilBuild=`) does **not** work — it patches `until-build=""` (an empty attribute) instead of removing it. `provider { null }` is the documented way to unset it. Deleting the property while keeping the `properties()` lookup would patch the literal string `until-build="null"`.
- Supersedes #262 and answers the question raised there about leaving the value empty.

Closes #262