### PR TITLE
build: improve runIde developer experience

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.date
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -80,6 +81,18 @@ intellijPlatform {
   pluginVerification { ides { recommended() } }
 }
 
+intellijPlatformTesting {
+  runIde {
+    register("runLatestIde") {
+      // The separate Community (IC) distribution is no longer published since 2025.3;
+      // the unified IntelliJ IDEA distribution replaces it.
+      type = IntelliJPlatformType.IntellijIdea
+      version = "2026.1.4"
+      task { jvmArgs("-Xmx2048m") }
+    }
+  }
+}
+
 tasks {
   // Set the JVM compatibility versions
   properties("javaVersion").let {
@@ -96,6 +109,10 @@ tasks {
   }
 
   wrapper { gradleVersion = "9.1.0" }
+
+  // Keep the sandbox heap above the 750MB threshold of MemorySizeConfigurator, which otherwise
+  // fails with an IOException trying to write vmoptions the sandbox does not have.
+  runIde { jvmArgs("-Xmx2048m") }
 
   patchPluginXml {
     pluginVersion.set(properties("pluginVersion"))


### PR DESCRIPTION
## What

Two quality-of-life improvements for the development sandbox:

1. **Raise the `runIde` sandbox heap to 2048m.** The platform's `MemorySizeConfigurator` startup activity attempts to rewrite the IDE's vmoptions whenever the current heap is at or below 750m ([source](https://github.com/JetBrains/intellij-community/blob/231.8109/platform/platform-impl/src/com/intellij/diagnostic/MemorySizeConfigurator.kt)). The sandbox has no vmoptions file (`jb.vmOptionsFile=null`), so every fresh sandbox logged:

   ```
   java.io.IOException: The IDE is not configured for using custom VM options (jb.vmOptionsFile=null)
       at com.intellij.diagnostic.VMOptions.setOptions(VMOptions.java:204)
   ```

   With the heap above the threshold the activity returns early and the exception is gone — and the dev IDE no longer runs on the 512m default.

2. **Add a `runLatestIde` task** that launches the plugin in IntelliJ IDEA 2026.1.4, while the default `runIde` keeps exercising the 2023.1 compatibility floor. Useful for day-to-day development: no ancient-platform log noise (VfsLog version mismatch, SdkDetector failing on modern JDKs, etc.) and you see the icons under the current UI.

## Notes

- `runLatestIde` uses `IntelliJPlatformType.IntellijIdea` (the unified distribution): the separate Community (IC) distribution is no longer published since 2025.3, so `IntellijIdeaCommunity` + a 2026.x version fails to resolve (`Could not find idea:ideaIC:2026.1`).
- Heads-up for the future: `platformType=IC` in `gradle.properties` still works for the 2023.1 baseline, but bumping `platformVersion` past 2025.3 will require the same IC → unified migration there.
- No changelog entry since this is developer-only tooling with no user-facing impact.