### PR TITLE
build: raise minimum supported IDE to 2025.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 25
+          # Gradle runs on this JDK, and the `test` task's toolchain also requests 21 so the tests
+          # run on a stock JDK rather than the JetBrains Runtime (see build.gradle.kts).
+          java-version: 21
           cache: 'gradle'
 
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 25
+          # Gradle runs on this JDK, and the `test` task's toolchain also requests 21 so the tests
+          # run on a stock JDK rather than the JetBrains Runtime (see build.gradle.kts).
+          java-version: 21
           cache: 'gradle'
 
       - name: Setup Gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,25 @@
 
 ### Changed
 
+- Raised the minimum supported IDE to 2025.2 (build 252) and now build against it, so the compiler
+  reports APIs deprecated after the minimum rather than hiding them until runtime
+- Verify the plugin against the whole supported build range: the IntelliJ IDEA Community
+  distribution stops at 2025.2, so 2025.3 and later are now covered by the unified distribution
+- Run tests on a stock JDK 21 instead of the JetBrains Runtime, which starts a thread the test
+  framework's leak detector does not recognise
+
 ### Deprecated
 
 ### Removed
 
+- No longer bundle `kotlin-stdlib` and `annotations` in the plugin distribution; they shadowed the
+  copies the IntelliJ Platform already provides
+
 ### Fixed
+
+- Declare Kotlin K2 mode support under the correct `org.jetbrains.kotlin` extension namespace, so it
+  is actually honoured
+- Call `PluginId.getId` in a way that still compiles against current platform versions
 
 ### Security
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.date
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -60,6 +61,17 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }
 
+// kotlinx-serialization drags in kotlin-stdlib (and the ancient org.jetbrains:annotations 13.0 that
+// stdlib depends on) transitively, which lands them in the plugin distribution's lib/ directory and
+// shadows the copies the IntelliJ Platform already ships. `kotlin.stdlib.default.dependency=false`
+// in gradle.properties only stops the Kotlin plugin from adding stdlib directly, not transitively.
+// The runtime classpath is what the distribution is assembled from, so exclude them there; the
+// compile classpath is left alone, since it takes both from the IntelliJ Platform dependency.
+configurations.runtimeClasspath {
+  exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+  exclude(group = "org.jetbrains", module = "annotations")
+}
+
 intellijPlatform {
   pluginConfiguration {
     id.set(properties("pluginGroup"))
@@ -78,7 +90,23 @@ intellijPlatform {
     }
   }
 
-  pluginVerification { ides { recommended() } }
+  pluginVerification {
+    ides {
+      // Covers the IntelliJ IDEA Community releases in range, which stop at 2025.2: the separate
+      // Community distribution is no longer published for 2025.3 and later.
+      recommended()
+
+      // Without this, verification silently stops at 2025.2 while the plugin advertises support up
+      // to `pluginUntilBuild`, because recommended() has no Community releases left to offer. The
+      // unified IntelliJ IDEA distribution replaces the Community one from 2025.3 (253) onwards.
+      select {
+        types = listOf(IntelliJPlatformType.IntellijIdea)
+        channels = listOf(ProductRelease.Channel.RELEASE)
+        sinceBuild = "253"
+        untilBuild = properties("pluginUntilBuild")
+      }
+    }
+  }
 }
 
 intellijPlatformTesting {
@@ -102,6 +130,10 @@ tasks {
     }
     withType<KotlinCompile> {
       compilerOptions {
+        // Must not exceed the Kotlin stdlib bundled with the IDE at pluginSinceBuild, since the
+        // plugin does not bundle its own stdlib (see the runtimeClasspath exclusions above) and
+        // resolves against the IDE's. 2025.2 (252) bundles stdlib 2.2.0, so this matches exactly.
+        // Raising it requires raising pluginSinceBuild to an IDE that bundles that stdlib.
         apiVersion = KotlinVersion.KOTLIN_2_2
         jvmTarget = JvmTarget.fromTarget(properties("javaVersion"))
       }
@@ -128,6 +160,17 @@ tasks {
   test {
     useJUnitPlatform()
     testLogging { events("passed", "skipped", "failed") }
+
+    // Run the tests on a stock JDK instead of the JetBrains Runtime the platform would otherwise
+    // supply. JBR starts a "SystemPropertyWatcher" thread (sun.awt.UNIXToolkit) that the test
+    // framework's leak detector does not recognise, so every run fails on a leaked thread that has
+    // nothing to do with the plugin. Suppressing it instead would mean calling ThreadLeakTracker,
+    // which is @ApiStatus.Internal. These tests cover PSI and icon resolution rather than real UI
+    // rendering, so a stock JDK of the same major version as the bundled JBR is close enough.
+    javaLauncher =
+      project.the<JavaToolchainService>().launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+      }
   }
 
   buildPlugin { dependsOn(test) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,13 @@
 pluginGroup=com.github.catppuccin.jetbrains_icons
 pluginName=Catppuccin Icons
 pluginVersion=1.13.2
-pluginSinceBuild=231
+pluginSinceBuild=252
 pluginUntilBuild=262.*
 platformType=IC
-platformVersion=2023.1
+# Keep this at the pluginSinceBuild release. Building against the oldest supported IDE is what makes
+# the compiler report APIs deprecated after it; targeting an older platform than the floor hides
+# those warnings until the Plugin Verifier or a user finds them.
+platformVersion=2025.2
 platformPlugins=org.jetbrains.kotlin,com.intellij.java
 javaVersion=17
 kotlin.stdlib.default.dependency=false

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/settings/PluginSettingsState.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.extensions.PluginId.getId
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.util.xmlb.XmlSerializerUtil
 
 @State(
@@ -16,7 +16,7 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState> {
   var variant = Variant.MOCHA.id
 
   var pythonSupport = true
-  var javaSupport = isPluginInstalled(getId("com.intellij.java"))
+  var javaSupport = isPluginInstalled(PluginId.getId("com.intellij.java"))
   var goSupport = true
 
   override fun getState(): PluginSettingsState = this

--- a/src/main/kotlin/com/github/catppuccin/jetbrains_icons/settings/views/SettingsAdditionalSupportView.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains_icons/settings/views/SettingsAdditionalSupportView.kt
@@ -2,7 +2,7 @@ package com.github.catppuccin.jetbrains_icons.settings.views
 
 import com.github.catppuccin.jetbrains_icons.settings.PluginSettingsState
 import com.intellij.ide.plugins.PluginManager.isPluginInstalled
-import com.intellij.openapi.extensions.PluginId.findId
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.util.ui.FormBuilder
 import java.awt.FlowLayout
@@ -12,7 +12,7 @@ class SettingsAdditionalSupportView : JPanel() {
   val python = JBCheckBox("Python", PluginSettingsState.instance.pythonSupport)
   val java =
     JBCheckBox("Java Filetypes", PluginSettingsState.instance.javaSupport).apply {
-      isEnabled = isPluginInstalled(findId("com.intellij.java"))
+      isEnabled = isPluginInstalled(PluginId.getId("com.intellij.java"))
     }
   val go = JBCheckBox("Go", PluginSettingsState.instance.goSupport)
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,7 +52,15 @@ For further help, see also:
     />
     <postStartupActivity implementation="com.github.catppuccin.jetbrains_icons.activity.IconPathPatcherActivity"/>
   </extensions>
-  <extensions defaultExtensionNs="com.intellij.kotlin">
+  <!--
+    Namespaced "org.jetbrains.kotlin" (the Kotlin plugin's ID, which declares this extension point)
+    rather than "com.intellij.kotlin", which resolves to nothing and leaves K2 mode undeclared.
+
+    This has to live in the main descriptor even though the org.jetbrains.kotlin dependency is
+    optional: the Plugin Verifier only reads this file, and reports the mode as undeclared when the
+    extension is in the optional config file instead.
+  -->
+  <extensions defaultExtensionNs="org.jetbrains.kotlin">
     <supportsKotlinPluginMode supportsK2="true"/>
   </extensions>
   <resource-bundle>messages.PluginSettingsBundle</resource-bundle>

--- a/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/IconAssertions.kt
+++ b/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/IconAssertions.kt
@@ -1,0 +1,23 @@
+package com.github.com.catppuccin.jetbrains_icons
+
+import com.intellij.ui.icons.IconPathProvider
+import javax.swing.Icon
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+
+/**
+ * Asserts that [actual] is the icon loaded from the same resource as [expected], comparing the
+ * paths they resolve to rather than the icon instances.
+ *
+ * Instance comparison is not reliable here. The tests build their own [Icons] instance while the
+ * providers use the one held by `IconPack`, so an assertion always compares two separately loaded
+ * icons, and `CachedImageIcon` does not treat two icons loaded from the same path as equal. The
+ * path is what the assertions actually care about: which SVG the provider picked.
+ */
+fun assertSameIcon(expected: Icon, actual: Icon?) {
+  val expectedPath = (expected as? IconPathProvider)?.originalPath
+  assertNotNull(expectedPath, "Expected icon does not expose a path: $expected")
+
+  val actualPath = (actual as? IconPathProvider)?.originalPath
+  assertEquals(expectedPath, actualPath, "Provider returned the wrong icon (actual: $actual)")
+}

--- a/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/IconProviderTest.kt
+++ b/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/IconProviderTest.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
 import com.intellij.testFramework.runInEdtAndGet
 import javax.swing.Icon
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class IconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
@@ -38,6 +37,6 @@ class IconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
     val provider = IconProvider()
     val icon = runInEdtAndGet { provider.getIcon(element(), 1) }
 
-    assertEquals(expected, icon)
+    assertSameIcon(expected, icon)
   }
 }

--- a/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/providers/JavaIconProviderTest.kt
+++ b/src/test/kotlin/com/github/com/catppuccin/jetbrains_icons/providers/JavaIconProviderTest.kt
@@ -3,6 +3,7 @@ package com.github.com.catppuccin.jetbrains_icons.providers
 import com.github.catppuccin.jetbrains_icons.Icons
 import com.github.catppuccin.jetbrains_icons.providers.JavaIconProvider
 import com.github.catppuccin.jetbrains_icons.settings.PluginSettingsState
+import com.github.com.catppuccin.jetbrains_icons.assertSameIcon
 import com.intellij.icons.AllIcons
 import com.intellij.ide.projectView.impl.ProjectViewState
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
@@ -47,7 +48,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeClass"), 1) }
 
-    assertEquals(icons.java_class, icon)
+    assertSameIcon(icons.java_class, icon)
   }
 
   @Test
@@ -63,7 +64,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeInterface"), 1) }
 
-    assertEquals(icons.java_interface, icon)
+    assertSameIcon(icons.java_interface, icon)
   }
 
   @Test
@@ -79,7 +80,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeEnum"), 1) }
 
-    assertEquals(icons.java_enum, icon)
+    assertSameIcon(icons.java_enum, icon)
   }
 
   @Test
@@ -95,7 +96,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeAnnotation"), 1) }
 
-    assertEquals(icons.java_annotation, icon)
+    assertSameIcon(icons.java_annotation, icon)
   }
 
   @Test
@@ -111,7 +112,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeRecord"), 1) }
 
-    assertEquals(icons.java_record, icon)
+    assertSameIcon(icons.java_record, icon)
   }
 
   @Test
@@ -127,7 +128,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeException"), 1) }
 
-    assertEquals(icons.java_exception, icon)
+    assertSameIcon(icons.java_exception, icon)
   }
 
   @Test
@@ -143,7 +144,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeSealedClass"), 1) }
 
-    assertEquals(icons.java_class_sealed, icon)
+    assertSameIcon(icons.java_class_sealed, icon)
   }
 
   @Test
@@ -159,7 +160,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeFinalClass"), 1) }
 
-    assertEquals(icons.java_class_final, icon)
+    assertSameIcon(icons.java_class_final, icon)
   }
 
   @Test
@@ -175,7 +176,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeAbstractClass"), 1) }
 
-    assertEquals(icons.java_class_abstract, icon)
+    assertSameIcon(icons.java_class_abstract, icon)
   }
 
   @Test
@@ -266,7 +267,7 @@ class JavaIconProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
     val icon = runInEdtAndGet { provider.getIcon(fixture.findClass("SomeClass"), 1) }
 
-    assertEquals(icons.java, icon)
+    assertSameIcon(icons.java, icon)
   }
 
   @Test


### PR DESCRIPTION
## Why

The plugin advertised support for builds `231..262` but was compiled against **2023.1**. Two consequences:

- The compiler could not report anything deprecated or changed after 2023.1. Finding those required disassembling platform jars.
- `pluginVerification { ides { recommended() } }` silently verified only **231..252** and never warned about the gap, because the IntelliJ IDEA **Community** distribution is not published for 2025.3 and later. Builds 253, 261 and 262 were advertised and never checked.

This raises `pluginSinceBuild` to `252` and builds against 2025.2.

## What raising the floor exposed

Both of these were latent and would have hit whoever bumped the platform next.

**`PluginId` no longer resolves.** It was rewritten from Java to Kotlin, moving its statics onto a companion, so `import com.intellij.openapi.extensions.PluginId.getId` fails to compile from Kotlin source:

```
e: PluginSettingsState.kt:8:49 Unresolved reference 'getId'.
e: SettingsAdditionalSupportView.kt:5:37 Unresolved reference 'findId'.
```

Now qualified. `getId` is used in both places — `findId` is `@Nullable` while `isPluginInstalled` takes a non-null id, so `findId` would also have been a nullability error.

**Eight icon tests failed** with `expected: X but was: Y` where both sides were the same SVG at the same path. The tests compared `CachedImageIcon` instances, but the plugin's `IconPack.icons` and the tests' own `Icons("mocha")` are separate instances that are never `equals`, so the assertions relied on incidental identity. They now compare the resolved resource path via `IconPathProvider.getOriginalPath()`, which is what they actually mean.

## Other fixes

**K2 mode was never declared.** The extension used `defaultExtensionNs="com.intellij.kotlin"`, but the extension point is declared by the Kotlin plugin, so it is `org.jetbrains.kotlin`. The old declaration resolved to nothing, and the verifier reported the mode as undeclared on every IDE from 2024.2 onward.

**Stopped bundling `kotlin-stdlib` and `annotations-13.0`.** `kotlinx-serialization` pulled them in transitively, defeating `kotlin.stdlib.default.dependency=false` (which only stops the Kotlin plugin adding stdlib directly). Both shadowed copies the platform already ships in `lib/util-8.jar` and `lib/annotations.jar`. Distribution drops from 8 files / 4.1 MB to 6 files / 2.3 MB.

This also restores a safety property: while the plugin bundled its own stdlib, a stdlib API missing from an older IDE would have been silently satisfied and invisible to the verifier. It is now a hard verification failure.

**Tests run on a stock JDK 21** instead of the JetBrains Runtime. JBR starts a `SystemPropertyWatcher` thread (`sun.awt.UNIXToolkit`) that is not in the 2025.2 test framework's `wellKnownOffenders` list, failing every run on a leaked thread unrelated to the plugin. The alternative was registering it through `ThreadLeakTracker`, which is `@ApiStatus.Internal`. These tests cover PSI and icon resolution rather than real UI rendering. CI now installs JDK 21.

## Verification

`recommended()` is kept for the Community releases in range and paired with a `select` block that picks up the unified distribution from 253, tracking `pluginUntilBuild` automatically so bumping that property extends coverage without a second edit.

```
Scheduled verifications (4):
  IC-252.28539.54: Compatible
  IU-253.33813.25: Compatible
  IU-261.26222.65: Compatible
  IU-262.8665.337: Compatible
```

No compatibility problems and no warnings — previously there was one warning on every IDE from 2024.2 up. `checkFormatting`, `runStaticAnalysis` (detekt, 0 findings) and all 34 tests pass.

## Note

`javaVersion` stays at 17: 2025.2 platform classes are still Java 17 bytecode, same as 2023.1.

Raising `sinceBuild` does not break existing users on older IDEs — the Marketplace keeps serving them the last compatible build; they stop receiving updates.
